### PR TITLE
Fix 'NameError: uninitialized constant PKG_NAME'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ task 'test' => ['test:unit', 'test:integration']
 
 task :default => :test
 
-Dir.glob('**/*.rake').each do |task_file|
+Dir.glob('tasks/*.rake').each do |task_file|
   load task_file
 end
 


### PR DESCRIPTION
When I ran `bundle exec rake -T`, I received the following error:

```shell
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
rake aborted!
NameError: uninitialized constant PKG_NAME
vendor/bundle/ruby/2.3.0/gems/addressable-2.4.0/tasks/gem.rake:5:in `block (2 levels) in <top (required)>'
vendor/bundle/ruby/2.3.0/gems/addressable-2.4.0/tasks/gem.rake:4:in `new'
vendor/bundle/ruby/2.3.0/gems/addressable-2.4.0/tasks/gem.rake:4:in `block in <top (required)>'
vendor/bundle/ruby/2.3.0/gems/addressable-2.4.0/tasks/gem.rake:3:in `<top (required)>'
/Users/adomokos/Programming/Ruby/oss/aws-sdk-ruby-record/Rakefile:23:in `load'
/Users/adomokos/Programming/Ruby/oss/aws-sdk-ruby-record/Rakefile:23:in `block in <top (required)>'
/Users/adomokos/Programming/Ruby/oss/aws-sdk-ruby-record/Rakefile:22:in `each'
/Users/adomokos/Programming/Ruby/oss/aws-sdk-ruby-record/Rakefile:22:in `<top (required)>'
/Users/adomokos/Programming/Ruby/oss/aws-sdk-ruby-record/vendor/bundle/ruby/2.3.0/gems/rake-11.2.2/exe/rake:27:in `<top (required)>'
(See full trace by running task with --trace)
```

I believe the problem is loading more files than you have to for rake.

With the change, listing of the tasks work properly:

```shell
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
rake coveralls:push    # Push latest coverage results to Coveralls.io
rake docs              # Generate doc files
rake docs:zip          # Generates docs.zip
rake gems:build        # Builds the aws-record gem
rake release           # Public release, `VERSION=x.y.z rake release`
rake test              # Runs unit and integration tests
rake test:integration  # Runs integration tests / aws-record integration tests
rake test:unit         # Runs unit tests / aws-record unit tests
```

OS: OS X 10.11.6
Ruby version: ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin15]