### PR TITLE
Fix 'already initialized constant' warning

### DIFF
--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -462,7 +462,7 @@ module Aws
 
       describe "validations with ActiveModel::Validations" do
         let(:klass_amv) do
-          ::TestTable = Class.new do
+          ::TestTable ||= Class.new do
             include(Aws::Record)
             include(ActiveModel::Validations)
             set_table_name("TestTable")


### PR DESCRIPTION
When I ran `bundle exec rake test`, I received the following warning:

```shell
................................................................................
/aws-record/record/item_operations_spec.rb:465: warning:
already initialized constant TestTable
/spec/aws-record/record/item_operations_spec.rb:465:
warning: previous definition of TestTable was here
............................................................................................................
```

This change fixes this warning.