### PR TITLE
Avoid an empty ExpressionAttributeValues when only removing attributes on update/save

### DIFF
--- a/lib/aws-record/record/item_operations.rb
+++ b/lib/aws-record/record/item_operations.rb
@@ -136,13 +136,14 @@ module Aws
           )
           if update_tuple
             uex, exp_attr_names, exp_attr_values = update_tuple
-            dynamodb_client.update_item(
+            request_opts = {
               table_name: self.class.table_name,
               key: key_values,
               update_expression: uex,
               expression_attribute_names: exp_attr_names,
-              expression_attribute_values: exp_attr_values
-            )
+            }
+            request_opts[:expression_attribute_values] = exp_attr_values unless exp_attr_values.empty?
+            dynamodb_client.update_item(request_opts)
           else
             dynamodb_client.update_item(
               table_name: self.class.table_name,
@@ -302,7 +303,7 @@ module Aws
             uex, exp_attr_names, exp_attr_values = update_tuple
             request_opts[:update_expression] = uex
             request_opts[:expression_attribute_names] = exp_attr_names
-            request_opts[:expression_attribute_values] = exp_attr_values
+            request_opts[:expression_attribute_values] = exp_attr_values unless exp_attr_values.empty?
           end
           dynamodb_client.update_item(request_opts)
         end

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -293,6 +293,22 @@ module Aws
           }])
         end
 
+        it 'will recognize nil as a removal operation even if it is the only operation' do
+          klass.configure_client(client: stub_client)
+          klass.update(id: 1, date: "2016-07-20", body: nil)
+          expect(api_requests).to eq([{
+            table_name: "TestTable",
+            key: {
+              "id" => { n: "1" },
+              "MyDate" => { s: "2016-07-20" }
+            },
+            update_expression: "REMOVE #UE_A",
+            expression_attribute_names: {
+              "#UE_A" => "body"
+            }
+          }])
+        end
+
         it 'will upsert even if only keys provided' do
           klass.configure_client(client: stub_client)
           klass.update(id: 1, date: "2016-05-18")


### PR DESCRIPTION
For attributes that have ```persist_nil: false``` (which is the default setting). Setting their value as ```nil``` will remove them from the persisted record.

However when these are the only attributes that are in the update/save request, an empty map would be generated, which subsequently gets rejected by the service.

This fix checks for that condition and prevents empty ExpressionAttributeValues from being sent in the request.