### PR TITLE
Add the #find_with_opts Method to Item Operations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in aws-record.gemspec
 gemspec
 
-gem 'rake', require: false
+gem 'rake', '< 11.0', require: false
 
 group :test do
   gem 'rspec', '~> 3.0.0'


### PR DESCRIPTION
This method allows for a variant of the `#find` operation which will let
users pass through other options to the underlying
`Aws::DynamoDB::Client#get_item` request.

Resolves #38, and relates to #46