### PR TITLE
add return_consumed_capacity to _perform_save

### DIFF
--- a/lib/aws-record/record/item_operations.rb
+++ b/lib/aws-record/record/item_operations.rb
@@ -141,13 +141,15 @@ module Aws
               key: key_values,
               update_expression: uex,
               expression_attribute_names: exp_attr_names,
+              return_consumed_capacity: (opts[:return_consumed_capacity] || "NONE"),
             }
             request_opts[:expression_attribute_values] = exp_attr_values unless exp_attr_values.empty?
             dynamodb_client.update_item(request_opts)
           else
             dynamodb_client.update_item(
               table_name: self.class.table_name,
-              key: key_values
+              key: key_values,
+              return_consumed_capacity: (opts[:return_consumed_capacity] || "NONE"),
             )
           end
         end

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -163,7 +163,8 @@ module Aws
             },
             expression_attribute_values: {
               ":ue_a" => { s: "Goodbye!" }
-            }
+            },
+            return_consumed_capacity: "NONE"
           }])
         end
 

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -167,6 +167,32 @@ module Aws
           }])
         end
 
+        it 'will pass the return_consumed_capacity argument to the dynamo update' do
+          klass.configure_client(client: stub_client)
+          item = klass.new
+          item.id = 1
+          item.date = '2015-12-14'
+          item.body = 'Hello!'
+          item.clean! # I'm claiming that it is this way in the DB now.
+          item.body = 'Goodbye!'
+          item.save(return_consumed_capacity: "TOTAL")
+          expect(api_requests).to eq([{
+            table_name: "TestTable",
+            key: {
+              "id" => { n: "1" },
+              "MyDate" => { s: "2015-12-14" }
+            },
+            update_expression: "SET #UE_A = :ue_a",
+            expression_attribute_names: {
+              "#UE_A" => "body"
+            },
+            expression_attribute_values: {
+              ":ue_a" => { s: "Goodbye!" }
+            },
+            return_consumed_capacity: "TOTAL"
+          }])
+        end
+
         it 'raises an exception when the conditional check fails' do
           stub_client.stub_responses(:put_item,
             'ConditionalCheckFailedException'


### PR DESCRIPTION
I want to be able to see how much write capacity individual saves are consuming. At the moment I think it's not possible. This PR allows for a `return_consumed_capacity` option to be passed in to `save` calls, and it passes that option through to the `dynamodb_client.update_item` update call, like this:

```ruby
> u.save return_consumed_capacity: "TOTAL"

[Aws::DynamoDB::Client 200 0.024123 0 retries] update_item(table_name:"some_table",key:{"id"=>{s:"4e95893384d7ec000300c62b"}},return_consumed_capacity:"TOTAL")

=> #<struct Aws::DynamoDB::Types::UpdateItemOutput
 attributes=nil,
 consumed_capacity=
  #<struct Aws::DynamoDB::Types::ConsumedCapacity
   table_name="some_table",
   capacity_units=10.0,
   table=nil,
   local_secondary_indexes=nil,
   global_secondary_indexes=nil>,
 item_collection_metrics=nil>
```

LMK if the approach looks good?