### PR TITLE
Attribute default_value changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Unreleased Changes
   date_attr :date, default_value -> { Date.today }
   ```
 
+* Issue - An attribute's default_value could be modified and carried over to
+  new instances of the model.
+
+  See [related GitHub issue #69](https://github.com/aws/aws-sdk-ruby-record/issues/69)
+
 1.1.0 (2017-04-21)
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Unreleased Changes
 ------------------
 
+* Feature - Support lambdas for default values
+
+  ```ruby
+  date_attr :date, default_value -> { Date.today }
+  ```
+
 1.1.0 (2017-04-21)
 ------------------
 

--- a/lib/aws-record/record/attribute.rb
+++ b/lib/aws-record/record/attribute.rb
@@ -21,7 +21,7 @@ module Aws
     # within the model class and item instances.
     class Attribute
 
-      attr_reader :name, :database_name, :dynamodb_type, :default_value
+      attr_reader :name, :database_name, :dynamodb_type
 
       # @param [Symbol] name Name of the attribute. It should be a name that is
       #  safe to use as a method.
@@ -53,7 +53,7 @@ module Aws
         @marshaler = options[:marshaler] || DefaultMarshaler
         @persist_nil = options[:persist_nil]
         dv = options[:default_value]
-        @default_value = type_cast(dv) unless dv.nil?
+        @default_value_or_lambda = type_cast(dv) unless dv.nil?
       end
 
       # Attempts to type cast a raw value into the attribute's type. This call
@@ -88,6 +88,15 @@ module Aws
       # @api private
       def extract(dynamodb_item)
         dynamodb_item[@database_name]
+      end
+
+      # @api private
+      def default_value
+        if @default_value_or_lambda.respond_to?(:call)
+          @default_value_or_lambda.call
+        else
+          @default_value_or_lambda
+        end
       end
 
     end

--- a/lib/aws-record/record/attribute.rb
+++ b/lib/aws-record/record/attribute.rb
@@ -95,8 +95,13 @@ module Aws
         if @default_value_or_lambda.respond_to?(:call)
           @default_value_or_lambda.call
         else
-          @default_value_or_lambda
+          _deep_copy(@default_value_or_lambda)
         end
+      end
+
+      private
+      def _deep_copy(obj)
+        Marshal.load(Marshal.dump(obj))
       end
 
     end

--- a/spec/aws-record/record/attribute_spec.rb
+++ b/spec/aws-record/record/attribute_spec.rb
@@ -36,6 +36,13 @@ module Aws
           a = Attribute.new(:foo, default_value: -> { 2 + 3 })
           expect(a.default_value).to eq(5)
         end
+
+        it 'uses a deep copy' do
+          a = Attribute.new(:foo, default_value: {})
+          a.default_value['greeting'] = 'hi'
+
+          expect(a.default_value).to eq({})
+        end
       end
 
     end

--- a/spec/aws-record/record/attribute_spec.rb
+++ b/spec/aws-record/record/attribute_spec.rb
@@ -31,6 +31,13 @@ module Aws
         end
       end
 
+      context 'default_value' do
+        it 'supports lambdas' do
+          a = Attribute.new(:foo, default_value: -> { 2 + 3 })
+          expect(a.default_value).to eq(5)
+        end
+      end
+
     end
   end
 end

--- a/spec/aws-record/record_spec.rb
+++ b/spec/aws-record/record_spec.rb
@@ -144,5 +144,21 @@ module Aws
       end
     end
 
+    describe 'default_value' do
+      let(:model) {
+        Class.new do
+          include(Aws::Record)
+          set_table_name("TestTable")
+          string_attr(:uuid, hash_key: true)
+          map_attr(:things, default_value: {})
+        end
+      }
+
+      it 'uses a deep copy of the default_value' do
+        model.new.things['foo'] = 'bar'
+        expect(model.new.things).to eq({})
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Sorry there are two different things in this pull request. Let me know if you want me to separate them out or if you aren't interested in one or the other:

* Adding support for using a lambda for `default_value` 
* Preventing modifications to an attribute's `default_value` [issue](https://github.com/aws/aws-sdk-ruby-record/issues/69)
