### PR TITLE
Changed to Default Value Behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Unreleased Changes
   date_attr :date, default_value -> { Date.today }
   ```
 
+* Issue - An attribute's default_value could be modified and carried over to
+  new instances of the model.
+
+  See [related GitHub issue #69](https://github.com/aws/aws-sdk-ruby-record/issues/69)
+
 1.1.0 (2017-04-21)
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 Unreleased Changes
 ------------------
 
-* Feature - Support lambdas for default values
+* Feature - Support lambdas for default attribute values.
 
   ```ruby
   date_attr :date, default_value -> { Date.today }
   ```
 
 * Issue - An attribute's default_value could be modified and carried over to
-  new instances of the model.
+  new instances of the model. With this change, default values are deep copied,
+  and are hydrated at item creation to ensure correct persistence of mutable
+  objects.
 
   See [related GitHub issue #69](https://github.com/aws/aws-sdk-ruby-record/issues/69)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Unreleased Changes
 ------------------
 
+* Feature - Support lambdas for default values
+
+  ```ruby
+  date_attr :date, default_value -> { Date.today }
+  ```
+
 1.1.0 (2017-04-21)
 ------------------
 

--- a/features/items/item_default_values.feature
+++ b/features/items/item_default_values.feature
@@ -1,0 +1,76 @@
+# Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+# language: en
+@dynamodb @item @default_values
+Feature: Aws::Record Attribute Default Values
+
+  Scenario: Write From Default Values
+    Given an aws-record model with definition:
+      """
+      string_attr :id, hash_key: true
+      map_attr :map, default_value: {}
+      """
+    And a TableConfig of:
+      """
+      Aws::Record::TableConfig.define do |t|
+        t.model_class(TableConfigTestModel)
+        t.read_capacity_units(1)
+        t.write_capacity_units(1)
+        t.client_options(region: "us-east-1")
+      end
+      """
+    When we migrate the TableConfig
+    And eventually the table should exist in DynamoDB
+    And we create a new instance of the model with attribute value pairs:
+      """
+      [
+        ["id", "1"]
+      ]
+      """
+    And we apply the following keys and values to map attribute "map":
+      """
+      { "a" => "1" }
+      """
+    And we save the model instance
+    And we create a new instance of the model with attribute value pairs:
+      """
+      [
+        ["id", "2"]
+      ]
+      """
+    And we apply the following keys and values to map attribute "map":
+      """
+      { "b" => "2" }
+      """
+    And we save the model instance
+    When we call the 'find' class method with parameter data:
+      """
+      {
+        "id": "1"
+      }
+      """
+    Then the attribute "map" on the item should match:
+      """
+      { "a" => "1" }
+      """
+      When we call the 'find' class method with parameter data:
+      """
+      {
+        "id": "2"
+      }
+      """
+    Then the attribute "map" on the item should match:
+      """
+      { "b" => "2" }
+      """

--- a/features/items/step_definitions.rb
+++ b/features/items/step_definitions.rb
@@ -54,3 +54,17 @@ Then(/^calling save should raise a conditional save exception$/) do
     Aws::Record::Errors::ConditionalWriteFailed
   )
 end
+
+When(/^we apply the following keys and values to map attribute "([^"]*)":$/) do |attribute, map_block|
+  # This code will explode, probably with a NoMethodError, if you put in a
+  # non-map attribute. It also intentionally uses mutation over assignment.
+  value = @instance.send(:"#{attribute}")
+  map = eval(map_block)
+  value.merge!(map)
+end
+
+Then(/^the attribute "([^"]*)" on the item should match:$/) do |attribute, value_block|
+  expected = eval(value_block)
+  actual = @instance.send(:"#{attribute}")
+  expect(actual).to eq(expected)
+end

--- a/lib/aws-record/record/attribute.rb
+++ b/lib/aws-record/record/attribute.rb
@@ -21,7 +21,7 @@ module Aws
     # within the model class and item instances.
     class Attribute
 
-      attr_reader :name, :database_name, :dynamodb_type, :default_value
+      attr_reader :name, :database_name, :dynamodb_type
 
       # @param [Symbol] name Name of the attribute. It should be a name that is
       #  safe to use as a method.
@@ -53,7 +53,7 @@ module Aws
         @marshaler = options[:marshaler] || DefaultMarshaler
         @persist_nil = options[:persist_nil]
         dv = options[:default_value]
-        @default_value = type_cast(dv) unless dv.nil?
+        @default_value_or_lambda = type_cast(dv) unless dv.nil?
       end
 
       # Attempts to type cast a raw value into the attribute's type. This call
@@ -88,6 +88,15 @@ module Aws
       # @api private
       def extract(dynamodb_item)
         dynamodb_item[@database_name]
+      end
+
+      # @api private
+      def default_value
+        if @default_value_or_lambda.respond_to?(:call)
+          @default_value_or_lambda.call
+        else
+          @default_value_or_lambda
+        end
       end
 
     end

--- a/lib/aws-record/record/attribute.rb
+++ b/lib/aws-record/record/attribute.rb
@@ -95,8 +95,13 @@ module Aws
         if @default_value_or_lambda.respond_to?(:call)
           @default_value_or_lambda.call
         else
-          @default_value_or_lambda
+          _deep_copy(@default_value_or_lambda)
         end
+      end
+
+      private
+      def _deep_copy(obj)
+        Marshal.load(Marshal.dump(obj))
       end
 
     end

--- a/lib/aws-record/record/item_data.rb
+++ b/lib/aws-record/record/item_data.rb
@@ -23,6 +23,7 @@ module Aws
         @model_attributes = model_attributes
         @track_mutations = opts[:track_mutations]
         @track_mutations = true if opts[:track_mutations].nil?
+        populate_default_values
       end
 
       def get_attribute(name)

--- a/spec/aws-record/record/attribute_spec.rb
+++ b/spec/aws-record/record/attribute_spec.rb
@@ -36,6 +36,13 @@ module Aws
           a = Attribute.new(:foo, default_value: -> { 2 + 3 })
           expect(a.default_value).to eq(5)
         end
+
+        it 'uses a deep copy' do
+          a = Attribute.new(:foo, default_value: {})
+          a.default_value['greeting'] = 'hi'
+
+          expect(a.default_value).to eq({})
+        end
       end
 
     end

--- a/spec/aws-record/record/attribute_spec.rb
+++ b/spec/aws-record/record/attribute_spec.rb
@@ -31,6 +31,13 @@ module Aws
         end
       end
 
+      context 'default_value' do
+        it 'supports lambdas' do
+          a = Attribute.new(:foo, default_value: -> { 2 + 3 })
+          expect(a.default_value).to eq(5)
+        end
+      end
+
     end
   end
 end

--- a/spec/aws-record/record/dirty_tracking_spec.rb
+++ b/spec/aws-record/record/dirty_tracking_spec.rb
@@ -279,6 +279,26 @@ describe Aws::Record::DirtyTracking do
       end
     end
 
+    describe "Default Values" do
+      let(:klass_with_defaults) do
+        Class.new do
+          include(Aws::Record)
+          set_table_name(:test_table)
+          string_attr(:mykey, hash_key: true)
+          map_attr(:dirty_map, default_value: {})
+        end
+      end
+
+      it 'tracks mutations to the default value' do
+        item = klass_with_defaults.new(mykey: "key")
+        item.clean!
+        expect(item.dirty?).to be_falsy
+        item.dirty_map[:key] = "value"
+        expect(item.dirty_map).to eq({ key: "value" })
+        expect(item.dirty?).to be_truthy
+      end
+    end
+
     describe "Tracking Turned Off" do
       it 'does not track detailed mutations when tracking is globally off' do
         klass.disable_mutation_tracking

--- a/spec/aws-record/record_spec.rb
+++ b/spec/aws-record/record_spec.rb
@@ -144,5 +144,21 @@ module Aws
       end
     end
 
+    describe 'default_value' do
+      let(:model) {
+        Class.new do
+          include(Aws::Record)
+          set_table_name("TestTable")
+          string_attr(:uuid, hash_key: true)
+          map_attr(:things, default_value: {})
+        end
+      }
+
+      it 'uses a deep copy of the default_value' do
+        model.new.things['foo'] = 'bar'
+        expect(model.new.things).to eq({})
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Resolves an issue where the class-level default value could be mutated, and carry across items. Additionally, ensures that mutated default values are not clobbered by eagerly hydrating them at item creation time.

Addresses #69 and a replacement for #70 