### PR TITLE
Default value lambda improvements

### DIFF
--- a/lib/aws-record/record/attribute.rb
+++ b/lib/aws-record/record/attribute.rb
@@ -54,7 +54,7 @@ module Aws
         @persist_nil = options[:persist_nil]
         dv = options[:default_value]
         unless dv.nil?
-          @default_value_or_lambda = dv.respond_to?(:call) ? dv : type_cast(dv)
+          @default_value_or_lambda = _is_lambda?(dv) ? dv : type_cast(dv)
         end
       end
 
@@ -94,7 +94,7 @@ module Aws
 
       # @api private
       def default_value
-        if @default_value_or_lambda.respond_to?(:call)
+        if _is_lambda?(@default_value_or_lambda)
           type_cast(@default_value_or_lambda.call)
         else
           _deep_copy(@default_value_or_lambda)
@@ -104,6 +104,10 @@ module Aws
       private
       def _deep_copy(obj)
         Marshal.load(Marshal.dump(obj))
+      end
+
+      def _is_lambda?(obj)
+        obj.respond_to?(:call)
       end
 
     end

--- a/lib/aws-record/record/attribute.rb
+++ b/lib/aws-record/record/attribute.rb
@@ -95,7 +95,7 @@ module Aws
       # @api private
       def default_value
         if @default_value_or_lambda.respond_to?(:call)
-          @default_value_or_lambda.call
+          type_cast(@default_value_or_lambda.call)
         else
           _deep_copy(@default_value_or_lambda)
         end

--- a/lib/aws-record/record/attribute.rb
+++ b/lib/aws-record/record/attribute.rb
@@ -53,7 +53,9 @@ module Aws
         @marshaler = options[:marshaler] || DefaultMarshaler
         @persist_nil = options[:persist_nil]
         dv = options[:default_value]
-        @default_value_or_lambda = type_cast(dv) unless dv.nil?
+        unless dv.nil?
+          @default_value_or_lambda = dv.respond_to?(:call) ? dv : type_cast(dv)
+        end
       end
 
       # Attempts to type cast a raw value into the attribute's type. This call

--- a/lib/aws-record/record/item_data.rb
+++ b/lib/aws-record/record/item_data.rb
@@ -105,9 +105,9 @@ module Aws
 
       def populate_default_values
         @model_attributes.attributes.each do |name, attribute|
-          unless attribute.default_value.nil?
+          unless (default_value = attribute.default_value).nil?
             if @data[name].nil? && @data[name].nil?
-              @data[name] = attribute.default_value
+              @data[name] = default_value
             end
           end
         end

--- a/spec/aws-record/record/attribute_spec.rb
+++ b/spec/aws-record/record/attribute_spec.rb
@@ -44,6 +44,12 @@ module Aws
           expect(dv.respond_to?(:call)).to eq(true)
         end
 
+        it 'type casts result of calling a default_value lambda' do
+          m = Marshalers::StringMarshaler.new
+          a = Attribute.new(:foo, marshaler: m, default_value: -> { :huzzah })
+          expect(a.default_value).to be_a(String)
+        end
+
         it 'uses a deep copy' do
           a = Attribute.new(:foo, default_value: {})
           a.default_value['greeting'] = 'hi'

--- a/spec/aws-record/record/attribute_spec.rb
+++ b/spec/aws-record/record/attribute_spec.rb
@@ -37,6 +37,13 @@ module Aws
           expect(a.default_value).to eq(5)
         end
 
+        it 'does not type_cast lambdas' do
+          m = Marshalers::DateTimeMarshaler.new
+          a = Attribute.new(:foo, marshaler: m, default_value: -> { Time.now })
+          dv = a.instance_variable_get("@default_value_or_lambda")
+          expect(dv.respond_to?(:call)).to eq(true)
+        end
+
         it 'uses a deep copy' do
           a = Attribute.new(:foo, default_value: {})
           a.default_value['greeting'] = 'hi'


### PR DESCRIPTION
Improvements to using a lambda as a default value:

- Don't type_cast the actual lambda.
- Type cast the result of calling a default lambda.