### PR TITLE
Pagination Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
@@ -19,8 +18,6 @@ bundler_args: --without docs release repl
 
 matrix:
   include:
-    - rvm: 2.3.0
-      env: NEW_RAILS=1
     - rvm: 2.4.0
       env: NEW_RAILS=1
   exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Aws::Record::ItemCollection - Add the `#page` and `#last_evaluated_key` methods to `Aws::Record::ItemCollection`. This helps to support use cases where you'd like to control the result set size with the `:limit` parameter, or if you want to expose pagination capabilities to an outside caller, for example a list-type operation exposed in a web API.
+
 2.0.0 (2017-08-29)
 ------------------
 

--- a/features/searching/search.feature
+++ b/features/searching/search.feature
@@ -131,7 +131,6 @@ Feature: Amazon DynamoDB Querying and Scanning
       ]
       """
 
-  @wip
   Scenario: Paginate Manually With Multiple Calls
     When we call the 'scan' class method with parameter data:
       """

--- a/features/searching/search.feature
+++ b/features/searching/search.feature
@@ -130,3 +130,63 @@ Feature: Amazon DynamoDB Querying and Scanning
         }
       ]
       """
+
+  @wip
+  Scenario: Paginate Manually With Multiple Calls
+    When we call the 'scan' class method with parameter data:
+      """
+      {
+        "limit": 2
+      }
+      """
+    Then we should receive an aws-record page with 2 values from members:
+      """
+      [
+        {
+          "id": "1",
+          "count": 5,
+          "body": "First item."
+        },
+        {
+          "id": "1",
+          "count": 10,
+          "body": "Second item."
+        },
+        {
+          "id": "1",
+          "count": 15,
+          "body": "Third item."
+        },
+        {
+          "id": "2",
+          "count": 10,
+          "body": "Fourth item."
+        }
+      ]
+      """
+    When we call the 'scan' class method using the page's pagination token
+    Then we should receive an aws-record page with 2 values from members:
+      """
+      [
+        {
+          "id": "1",
+          "count": 5,
+          "body": "First item."
+        },
+        {
+          "id": "1",
+          "count": 10,
+          "body": "Second item."
+        },
+        {
+          "id": "1",
+          "count": 15,
+          "body": "Third item."
+        },
+        {
+          "id": "2",
+          "count": 10,
+          "body": "Fourth item."
+        }
+      ]
+      """

--- a/lib/aws-record/record/item_collection.rb
+++ b/lib/aws-record/record/item_collection.rb
@@ -38,11 +38,38 @@ module Aws
       def each(&block)
         return enum_for(:each) unless block_given?
         items.each_page do |page|
+          @last_evaluated_key = page.last_evaluated_key
           items_array = _build_items_from_response(page.items, @model)
           items_array.each do |item|
             yield item
           end
         end
+      end
+
+      # Provides the first "page" of responses from your query operation. This
+      # will only make a single client call, and will provide the items, if any
+      # exist, from that response. It will not attempt to follow up on
+      # pagination tokens, so this is not guaranteed to include all items that
+      # match your search.
+      #
+      # @return [Array<Aws::Record>] an array of the record items found in the
+      #   first page of reponses from the query or scan call.
+      def page
+        search_response = items
+        @last_evaluated_key = search_response.last_evaluated_key
+        _build_items_from_response(search_response.items, @model)
+      end
+
+      # Provides the pagination key most recently used by the underlying client.
+      # This can be useful in the case where you're exposing pagination to an
+      # outside caller, and want to be able to "resume" your scan in a new call
+      # without starting over.
+      #
+      # @return [Hash] a hash representing an attribute key/value pair, suitable
+      #   for use as the +exclusive_start_key+ in another query or scan
+      #   operation. If there are no more pages in the result, will be nil.
+      def last_evaluated_key
+        @last_evaluated_key
       end
 
       # Checks if the query/scan result is completely blank.


### PR DESCRIPTION
Add the `#page` and `#last_evaluated_key` methods to `Aws::Record::ItemCollection`. This helps to support use cases where you'd like to control the result set size with the `:limit` parameter, or if you want to expose pagination capabilities to an outside caller, for example a list-type operation exposed in a web API.