### PR TITLE
Use client set to migrating model if it exists

### DIFF
--- a/lib/aws-record/record/table_migration.rb
+++ b/lib/aws-record/record/table_migration.rb
@@ -31,7 +31,7 @@ module Aws
       def initialize(model, opts = {})
         _assert_model_valid(model)
         @model = model
-        @client = opts[:client] || Aws::DynamoDB::Client.new
+        @client = opts[:client] || model.dynamodb_client || Aws::DynamoDB::Client.new
       end
 
       # This method calls

--- a/spec/aws-record/record/table_migration_spec.rb
+++ b/spec/aws-record/record/table_migration_spec.rb
@@ -44,6 +44,27 @@ module Aws
         )
       end
 
+      context 'client' do
+        let(:model_stub_client) { Aws::DynamoDB::Client.new(stub_responses: true) }
+        let(:model) do
+          model = Class.new do
+            include(Aws::Record)
+            set_table_name("TestTable")
+            integer_attr(:id, hash_key: true)
+          end
+          model.configure_client client: model_stub_client
+          model
+        end
+
+        it 'uses client given as option with the highest priority' do
+          expect(TableMigration.new(model, client: stub_client).client).to eq stub_client
+        end
+
+        it 'uses client set to model' do
+          expect(TableMigration.new(model).client).to eq model_stub_client
+        end
+      end
+
       context "Migration Operations" do
 
         let(:klass) do


### PR DESCRIPTION
In table migration, I think we can use client set to the model (if it exists) rather than initializing plain client. What do you think?