### PR TITLE
TTL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Aws::Record::TableConfig - Adds `:ttl_attribute` to the TableConfig DSL. When used with `epoch_time_attr` attributes or other attributes stored as epoch time, your TableConfig migrations will enable TTL on your DynamoDB table, and will use your specified attribute as the TTL attribute.
+
 * Feature - Aws::Record::Marshalers::EpochTimeMarshaler - Adds the `epoch_time_attr`, which behaves much like `time_attr` except the Amazon DynamoDB storage type is numeric, and the serialized value is epoch seconds.
 
 2.1.0 (2018-06-25)

--- a/README.md
+++ b/README.md
@@ -65,18 +65,15 @@ class MyModel
 end
 ```
 
-If a matching table does not exist in DynamoDB, you can use table migrations to
-create your table.
+If a matching table does not exist in DynamoDB, you can use the TableConfig DSL to create your table:
 
 ```ruby
-migration = Aws::Record::TableMigration.new(MyModel)
-migration.create!(
-  provisioned_throughput: {
-    read_capacity_units: 5,
-    write_capacity_units: 2
-  }
-)
-migration.wait_until_available
+cfg = Aws::Record::TableConfig.define do |t|
+  t.model_class(MyModel)
+  t.read_capacity_units(5)
+  t.write_capacity_units(2)
+end
+cfg.migrate!
 ```
 
 With a table in place, you can then use your model class to manipulate items in

--- a/features/table_config/table_config.feature
+++ b/features/table_config/table_config.feature
@@ -146,3 +146,59 @@ Feature: Aws::Record::TableConfig
     When we migrate the TableConfig
     Then the TableConfig should be compatible with the remote table
     And the TableConfig should be an exact match with the remote table
+
+  @wip @ttl
+  Scenario: Create a New Table With TTL
+    Given an aws-record model with definition:
+      """
+      string_attr  :id,    hash_key: true
+      integer_attr :count, range_key: true
+      epoch_time_attr :ttl
+      """
+    And a TableConfig of:
+      """
+      Aws::Record::TableConfig.define do |t|
+        t.model_class(TableConfigTestModel)
+        t.read_capacity_units(2)
+        t.write_capacity_units(2)
+        t.ttl_attribute(:ttl)
+        t.client_options(region: "us-east-1")
+      end
+      """
+    When we migrate the TableConfig
+    Then eventually the table should exist in DynamoDB
+    And the TableConfig should be compatible with the remote table
+    And the TableConfig should be an exact match with the remote table
+
+  @wip @ttl
+  Scenario: Update an Existing Table With TTL
+    Given an aws-record model with definition:
+      """
+      string_attr  :id,    hash_key: true
+      integer_attr :count, range_key: true
+      epoch_time_attr :ttl
+      """
+    And a TableConfig of:
+      """
+      Aws::Record::TableConfig.define do |t|
+        t.model_class(TableConfigTestModel)
+        t.read_capacity_units(2)
+        t.write_capacity_units(2)
+        t.ttl_attribute(:ttl)
+        t.client_options(region: "us-east-1")
+      end
+      """
+    When we create a table migration for the model
+    And we call 'create!' with parameters:
+      """
+      {
+        "provisioned_throughput": {
+          "read_capacity_units": 2,
+          "write_capacity_units": 2
+        }
+      }
+      """
+    Then eventually the table should exist in DynamoDB
+    And the TableConfig should not be compatible with the remote table
+    When we migrate the TableConfig
+    Then the TableConfig should be compatible with the remote table

--- a/features/table_config/table_config.feature
+++ b/features/table_config/table_config.feature
@@ -147,7 +147,7 @@ Feature: Aws::Record::TableConfig
     Then the TableConfig should be compatible with the remote table
     And the TableConfig should be an exact match with the remote table
 
-  @wip @ttl
+  @ttl
   Scenario: Create a New Table With TTL
     Given an aws-record model with definition:
       """
@@ -170,7 +170,7 @@ Feature: Aws::Record::TableConfig
     And the TableConfig should be compatible with the remote table
     And the TableConfig should be an exact match with the remote table
 
-  @wip @ttl
+  @ttl
   Scenario: Update an Existing Table With TTL
     Given an aws-record model with definition:
       """

--- a/lib/aws-record/record/table_config.rb
+++ b/lib/aws-record/record/table_config.rb
@@ -74,6 +74,19 @@ module Aws
     #     end
     #   end
     #
+    #  @example A model with a Time to Live attribute
+    #    class ExpiringTokens
+    #      string_attr :token_uuid, hash_key: true
+    #      epoch_time_attr :ttl
+    #    end
+    #
+    #    table_config = Aws::Record::TableConfig.define do |t|
+    #      t.model_class ExpiringTokens
+    #      t.read_capacity_units 10
+    #      t.write_capacity_units 1
+    #      t.ttl_attribute :ttl
+    #    end
+    #
     class TableConfig
 
       attr_accessor :client
@@ -92,6 +105,8 @@ module Aws
         #     index.
         #   * +#write_capacity_units+ Sets the write capacity units for the
         #     index.
+        # * +#ttl_attribute+ Sets the attribute ID to be used as the TTL
+        #     attribute, and if present, TTL will be enabled for the table.
         #
         # @example Defining a migration with a GSI.
         #   class Forum


### PR DESCRIPTION
Adds `:ttl_attribute` to the TableConfig DSL. When used with `epoch_time_attr` attributes or other attributes stored as epoch time, your TableConfig migrations will enable TTL on your DynamoDB table, and will use your specified attribute as the TTL attribute.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
