### PR TITLE
Add Support for On-Demand Capacity to TableConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Aws::Record::TableConfig - Adds support for the "PAY_PER_REQUEST" billing mode in table configurations.
+
 2.1.2 (2018-11-15)
 ------------------
 

--- a/aws-record.gemspec
+++ b/aws-record.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.files = Dir['lib/**/*.rb']
 
-  spec.add_dependency('aws-sdk-dynamodb', '~> 1.0')
+  spec.add_dependency('aws-sdk-dynamodb', '~> 1.18')
 end

--- a/lib/aws-record/record/table_config.rb
+++ b/lib/aws-record/record/table_config.rb
@@ -389,7 +389,6 @@ module Aws
         if @billing_mode == "PROVISIONED"
           opts = {
             table_name: @model_class.table_name,
-            billing_mode: "PROVISIONED",
             provisioned_throughput: {
               read_capacity_units: @read_capacity_units,
               write_capacity_units: @write_capacity_units
@@ -398,11 +397,13 @@ module Aws
           # special case: we have global secondary indexes existing, and they
           # need provisioned capacity to be set within this call
           if !resp.table.billing_mode_summary.nil? &&
-              resp.table.billing_mode_summary.billing_mode == "PAY_PER_REQUEST" &&
-              resp.table.global_secondary_indexes
-            resp_gsis = resp.table.global_secondary_indexes
-            _add_global_secondary_index_throughput(opts, resp_gsis)
-          end
+              resp.table.billing_mode_summary.billing_mode == "PAY_PER_REQUEST"
+            opts[:billing_mode] = @billing_mode
+            if resp.table.global_secondary_indexes
+              resp_gsis = resp.table.global_secondary_indexes
+              _add_global_secondary_index_throughput(opts, resp_gsis)
+            end
+          end # else don't include billing mode
           opts
         elsif @billing_mode == "PAY_PER_REQUEST"
           {

--- a/spec/aws-record/record/table_config_spec.rb
+++ b/spec/aws-record/record/table_config_spec.rb
@@ -141,7 +141,6 @@ module Aws
           cfg.migrate!
           expect(api_requests[1]).to eq(
             table_name: "TestModel",
-            billing_mode: "PROVISIONED",
             provisioned_throughput:
             {
               read_capacity_units: 2,
@@ -402,7 +401,6 @@ module Aws
             cfg.migrate!
             expect(api_requests[1]).to eq(
               table_name: "TestModelWithGsi",
-              billing_mode: "PROVISIONED",
               provisioned_throughput: {
                 read_capacity_units: 2,
                 write_capacity_units: 2

--- a/spec/aws-record/record/table_config_spec.rb
+++ b/spec/aws-record/record/table_config_spec.rb
@@ -2414,6 +2414,20 @@ module Aws
           )
         end
 
+        it "will raise an argument error when given a nonsense billing mode" do
+          cfg = TableConfig.define do |t|
+            t.model_class(TestModel)
+            t.billing_mode("FREE_LUNCH")
+            t.client_options(stub_responses: true)
+          end
+          stub_client = configure_test_client(cfg.client)
+          stub_client.stub_responses(
+            :describe_table,
+            'ResourceNotFoundException',
+          )
+          expect { cfg.migrate! }.to raise_error(ArgumentError, "Unsupported billing mode FREE_LUNCH")
+        end
+
         it "will raise a validation error if ppr is set with throughput" do
           cfg = TableConfig.define do |t|
             t.model_class(TestModel)


### PR DESCRIPTION
This adds support for the "PAY_PER_REQUEST" billing mode, and has integration tests as well as unit tests for the different related scenarios.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
