### PR TITLE
Update readme to current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ gem install 'aws-record'
 ```
 
 ```ruby
-gem 'aws-record', '~> 1.0'
+gem 'aws-record', '~> 2.0'
 ```
 
 This automatically includes a dependency on the `aws-sdk-resources` gem, major
@@ -39,8 +39,8 @@ Gemfile if you need to lock to a specific version, like so:
 ```ruby
 # Gemfile
 
-gem 'aws-record', '~> 1.0'
-gem 'aws-sdk-resources', '~> 2.5'
+gem 'aws-record', '~> 2.0'
+gem 'aws-sdk-resources', '~> 3.0'
 ```
 
 ## Usage


### PR DESCRIPTION
The README is out of date. Both `aws-record` and `aws-sdk-resources` are outdated. 

As a side note, the actual dependency is on only `aws-sdk-dynamodb` which was separated in version 3.0. Would you prefer the install instructions be updated to the sub-gem resource?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
