### PR TITLE
Fixes BigDecimal deprecation warnings in specs

### DIFF
--- a/lib/aws-record/record/marshalers/numeric_set_marshaler.rb
+++ b/lib/aws-record/record/marshalers/numeric_set_marshaler.rb
@@ -58,7 +58,7 @@ module Aws
             if item.is_a?(Numeric)
               item
             else
-              BigDecimal.new(item.to_s)
+              BigDecimal(item.to_s)
             end
           end
         end

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -584,7 +584,7 @@ module Aws
 
       describe "validations with ActiveModel::Validations" do
         let(:klass_amv) do
-          ::TestTable = Class.new do
+          ::TestTable ||= Class.new do
             include(Aws::Record)
             include(ActiveModel::Validations)
             set_table_name("TestTable")

--- a/spec/aws-record/record/marshalers/epoch_time_marshaler_spec.rb
+++ b/spec/aws-record/record/marshalers/epoch_time_marshaler_spec.rb
@@ -44,7 +44,7 @@ module Aws
 
             it 'converts BigDecimal objects to Time' do
               expected = Time.at(1531173732)
-              input = BigDecimal.new(1531173732)
+              input = BigDecimal(1531173732)
               expect(@marshaler.type_cast(input)).to eq(expected)
             end
 

--- a/spec/aws-record/record/marshalers/numeric_set_marshaler_spec.rb
+++ b/spec/aws-record/record/marshalers/numeric_set_marshaler_spec.rb
@@ -46,7 +46,7 @@ module Aws
 
             it 'attempts to cast as numeric all contents of a set' do
               input = Set.new([1,'2.0', '3'])
-              expected = Set.new([1, BigDecimal.new('2.0'), BigDecimal.new('3')])
+              expected = Set.new([1, BigDecimal('2.0'), BigDecimal('3')])
               expect(@marshaler.type_cast(input)).to eq(expected)
             end
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* BigDecimal 1.4.0 deprecated the `BigDecimal.new()` instantiation approach in favor of `BigDecimal()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
