### PR TITLE
Suppress unhelpful warnings on Ruby 2.7

### DIFF
--- a/lib/aws-record/record/attribute.rb
+++ b/lib/aws-record/record/attribute.rb
@@ -53,9 +53,7 @@ module Aws
         @marshaler = options[:marshaler] || DefaultMarshaler
         @persist_nil = options[:persist_nil]
         dv = options[:default_value]
-        unless dv.nil?
-          @default_value_or_lambda = _is_lambda?(dv) ? dv : type_cast(dv)
-        end
+        @default_value_or_lambda = _is_lambda?(dv) ? dv : type_cast(dv)
       end
 
       # Attempts to type cast a raw value into the attribute's type. This call


### PR DESCRIPTION
Calling `[Attribute#default_value]` on record initialized with a
`:default_value` triggered the following warning:

```
instance variable @default_value_or_lambda not initialized
```

The warning's not particularly useful as the caller will simply get a
`nil` and carry on anyway[1]. By setting the variable to `nil` for
records without a `:default_value` we maintain this behaviour and
suppress the warning.

[1]: Later versions of Ruby simply suppress this warning

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
