### PR TITLE
Clean-up mutation tracking setup

### DIFF
--- a/lib/aws-record/record.rb
+++ b/lib/aws-record/record.rb
@@ -50,7 +50,6 @@ module Aws
     #     # Attribute definitions go here...
     #   end
     def self.included(sub_class)
-      @track_mutations = true
       sub_class.send(:extend, RecordClassMethods)
       sub_class.send(:include, Attributes)
       sub_class.send(:include, ItemOperations)
@@ -201,7 +200,11 @@ module Aws
       # @return [Boolean] true if mutation tracking is enabled at the model
       # level, false otherwise.
       def mutation_tracking_enabled?
-        @track_mutations == false ? false : true
+        if defined?(@track_mutations)
+          @track_mutations
+        else
+          @track_mutations = true
+        end
       end
 
       def model_valid?

--- a/spec/aws-record/record_spec.rb
+++ b/spec/aws-record/record_spec.rb
@@ -138,6 +138,10 @@ module Aws
         end
       }
 
+      it 'is on by default' do
+        expect(model.mutation_tracking_enabled?).to be_truthy
+      end
+
       it 'can turn off mutation tracking globally for a model' do
         model.disable_mutation_tracking
         expect(model.mutation_tracking_enabled?).to be_falsy


### PR DESCRIPTION
Similar to #112 including the `[Record]` module in a class would produce
the following warning:

```
warning: instance variable @track_mutations not initialized
```

This was because we were trying to set a default value for
`@track_mutations` in `.included`, creating an instance variable in the
`[Record]` module rather than in our target class.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
