### PR TITLE
Atomic counter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ doc
 coverage/
 vendor/bundle
 .bundle
+.idea
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased Changes
+------------------
+
+* Feature - Add support for atomic counter (#144)
+
 2.7.0 (master)
 ------------------
 

--- a/features/items/items.feature
+++ b/features/items/items.feature
@@ -138,7 +138,7 @@ Feature: Amazon DynamoDB Items
       }
       """
 
-  Scenario:  Increment Atomic Counter Attribute with a Custom Value
+  Scenario:  Increment Atomic Counter Attribute
     Given an aws-record model with data:
       """
       [
@@ -162,7 +162,7 @@ Feature: Amazon DynamoDB Items
         "rk": 6
       }
       """
-    When we call "increment_counter!" on aws-record item instance with a value of "1"
+    When we call "increment_counter!" on aws-record item instance
     And we call the 'find' class method with parameter data:
       """
       {
@@ -176,5 +176,21 @@ Feature: Amazon DynamoDB Items
         "id": "5",
         "rk": 6,
         "counter": 1
+      }
+      """
+    When we call "increment_counter!" on aws-record item instance with an integer value of "5"
+    And we call the 'find' class method with parameter data:
+      """
+      {
+        "id": "5",
+        "rk": 6
+      }
+      """
+    Then we should receive an aws-record item with attribute data:
+      """
+      {
+        "id": "5",
+        "rk": 6,
+        "counter": 6
       }
       """

--- a/features/items/items.feature
+++ b/features/items/items.feature
@@ -27,14 +27,14 @@ Feature: Amazon DynamoDB Items
       """
       [
         { "attribute_name": "id", "attribute_type": "S", "key_type": "HASH" },
-        { "attribute_name": "count", "attribute_type": "N", "key_type": "RANGE" }
+        { "attribute_name": "rk", "attribute_type": "N", "key_type": "RANGE" }
       ]
       """
     And an aws-record model with data:
       """
       [
         { "method": "string_attr", "name": "id", "hash_key": true },
-        { "method": "integer_attr", "name": "count", "range_key": true },
+        { "method": "integer_attr", "name": "rk", "range_key": true },
         { "method": "string_attr", "name": "body", "database_name": "content" }
       ]
       """
@@ -44,7 +44,7 @@ Feature: Amazon DynamoDB Items
       """
       [
         ["id", 1],
-        ["count", 1],
+        ["rk", 1],
         ["body", "Hello!"]
       ]
       """
@@ -53,7 +53,7 @@ Feature: Amazon DynamoDB Items
       """
       [
         ["id", "1"],
-        ["count", 1]
+        ["rk", 1]
       ]
       """
 
@@ -62,7 +62,7 @@ Feature: Amazon DynamoDB Items
       """
       {
         "id": "2",
-        "count": 10,
+        "rk": 10,
         "content": "Aliased column names!"
       }
       """
@@ -70,14 +70,14 @@ Feature: Amazon DynamoDB Items
       """
       {
         "id": "2",
-        "count": 10
+        "rk": 10
       }
       """
     Then we should receive an aws-record item with attribute data:
       """
       {
         "id": "2",
-        "count": 10,
+        "rk": 10,
         "body": "Aliased column names!"
       }
       """
@@ -87,7 +87,7 @@ Feature: Amazon DynamoDB Items
       """
       {
         "id": "3",
-        "count": 5,
+        "rk": 5,
         "content": "Body content."
       }
       """
@@ -95,7 +95,7 @@ Feature: Amazon DynamoDB Items
       """
       {
         "id": "3",
-        "count": 5
+        "rk": 5
       }
       """
     And we call 'delete!' on the aws-record item instance
@@ -103,7 +103,7 @@ Feature: Amazon DynamoDB Items
       """
       [
         ["id", "3"],
-        ["count", 5]
+        ["rk", 5]
       ]
       """
 
@@ -112,7 +112,7 @@ Feature: Amazon DynamoDB Items
       """
       {
         "id": "4",
-        "count": 5,
+        "rk": 5,
         "content": "Body content."
       }
       """
@@ -120,7 +120,7 @@ Feature: Amazon DynamoDB Items
       """
       {
         "id": "4",
-        "count": 5
+        "rk": 5
       }
       """
     And we call 'update' on the aws-record item instance with parameter data:
@@ -133,7 +133,8 @@ Feature: Amazon DynamoDB Items
       """
       {
         "id": "4",
-        "count": 5,
+        "rk": 5,
         "body": "Updated Body Content."
       }
       """
+

--- a/features/items/items.feature
+++ b/features/items/items.feature
@@ -138,3 +138,43 @@ Feature: Amazon DynamoDB Items
       }
       """
 
+  Scenario:  Increment Atomic Counter Attribute with a Custom Value
+    Given an aws-record model with data:
+      """
+      [
+        { "method": "string_attr", "name": "id", "hash_key": true },
+        { "method": "integer_attr", "name": "rk", "range_key": true },
+        { "method": "atomic_counter", "name": "counter" }
+      ]
+      """
+    And an item exists in the DynamoDB table with item data:
+      """
+      {
+        "id": "5",
+        "rk": 6,
+        "counter": 0
+      }
+      """
+    And we call the 'find' class method with parameter data:
+      """
+      {
+        "id": "5",
+        "rk": 6
+      }
+      """
+    When we call "increment_counter!" on aws-record item instance with a value of "1"
+    And we call the 'find' class method with parameter data:
+      """
+      {
+        "id": "5",
+        "rk": 6
+      }
+      """
+    Then we should receive an aws-record item with attribute data:
+      """
+      {
+        "id": "5",
+        "rk": 6,
+        "counter": 1
+      }
+      """

--- a/features/items/step_definitions.rb
+++ b/features/items/step_definitions.rb
@@ -74,10 +74,6 @@ Then(/^the attribute "([^"]*)" on the item should match:$/) do |attribute, value
   expect(actual).to eq(expected)
 end
 
-
-When(/^we call 'increment_counter!' on aws\-record item instance with parameter data:$/) do |string|
-  data = JSON.parse(string, symbolize_names: true)
-  puts data
-
-
+When(/^we call "([^"]*)" on aws\-record item instance with a value of "([^"]*)"$/) do |method, value|
+  @instance.send(method, value.to_i)
 end

--- a/features/items/step_definitions.rb
+++ b/features/items/step_definitions.rb
@@ -73,3 +73,11 @@ Then(/^the attribute "([^"]*)" on the item should match:$/) do |attribute, value
   actual = @instance.send(:"#{attribute}")
   expect(actual).to eq(expected)
 end
+
+
+When(/^we call 'increment_counter!' on aws\-record item instance with parameter data:$/) do |string|
+  data = JSON.parse(string, symbolize_names: true)
+  puts data
+
+
+end

--- a/features/items/step_definitions.rb
+++ b/features/items/step_definitions.rb
@@ -74,6 +74,10 @@ Then(/^the attribute "([^"]*)" on the item should match:$/) do |attribute, value
   expect(actual).to eq(expected)
 end
 
-When(/^we call "([^"]*)" on aws\-record item instance with a value of "([^"]*)"$/) do |method, value|
-  @instance.send(method, value.to_i)
+When(/^we call "([^"]*)" on aws\-record item instance(?: with an integer value of "(-?\d+)")?$/) do |method, value|
+  if value
+    @instance.send(method, value)
+  else
+    @instance.send(method)
+  end
 end

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -412,7 +412,7 @@ module Aws
         #     atomic_counter :counter
         #   end
         #
-        #   record = MyRecord.new(id: 1)
+        #   record = MyRecord.find(id: 1)
         #   record.counter #=> 0
         #   record.increment_counter! #=> 1
         #   record.increment_counter!(2) #=> 3

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -390,16 +390,15 @@ module Aws
           opts[:default_value] ||= 0 # if user does not define default_value in their model, default is 0
           attr(name, Marshalers::IntegerMarshaler.new(opts), opts)
 
-          # increment method with no args
           define_method("increment_#{name}!") do |increment=1|
             puts "Increasing #{name}!"
 
             # need to discuss how I can update
-            # this to today's standards
+            # this to today's ruby standards
+            # also - would this be considered to be a RecordError?
             if dirty?
-              raise Errors::RecordError.new(
-                "Time to Take a Bath"
-              )
+              msg = "Attributes need to be saved before proceeding"
+              raise Errors::RecordError, msg
             end
 
             # check if passed-in arg is an integer

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -391,25 +391,17 @@ module Aws
           attr(name, Marshalers::IntegerMarshaler.new(opts), opts)
 
           define_method("increment_#{name}!") do |increment=1|
-            puts "Increasing #{name}!"
 
-            # need to discuss how I can update
-            # this to today's ruby standards
-            # also - would this be considered to be a RecordError?
             if dirty?
               msg = "Attributes need to be saved before atomic counter can be incremented"
               raise Errors::RecordError, msg
             end
 
-            # check if passed-in arg is an integer
-            # if it is not, need to raise Error
-            unless increment.is_a?(Integer) # look into unless keyword
+            unless increment.is_a?(Integer)
               msg = "expected an Integer value, got #{increment.class}"
               raise ArgumentError, msg
             end
 
-            # will successfully update the
-            # atomic_counter by 1 by default
             resp = dynamodb_client.update_item({
               table_name: self.class.table_name,
               key: key_values,
@@ -423,17 +415,14 @@ module Aws
               return_values: "UPDATED_NEW"
             })
             assign_attributes(resp[:attributes])
-            # returns true when completed
-            # do we want something else to be returned at end
+
             @data.clean!
 
-            # return the current value of the counter
+            # after discussion with Alex, we agreed that the
+            # return value should be the current value of the atomic_counter
+            @data.get_attribute(name)
+
           end
-
-
-
-
-
         end
 
         # @return [Symbol,nil] The symbolic name of the table's hash key.

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -391,7 +391,7 @@ module Aws
           attr(name, Marshalers::IntegerMarshaler.new(opts), opts)
 
           # increment method with no args
-          define_method("increment_#{name}!") do
+          define_method("increment_#{name}!") do |arg=1|
             puts "Increasing #{name}!"
 
             # need to discuss how I can update
@@ -403,12 +403,12 @@ module Aws
             end
 
             # will successfully update the
-            # atomic_counter by 1
+            # atomic_counter by 1 by default
             resp = dynamodb_client.update_item({
               table_name: self.class.table_name,
               key: key_values,
               expression_attribute_values: {
-                ":i" => 1
+                ":i" => arg
               },
               expression_attribute_names: {
                 "#n" => name

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -382,6 +382,10 @@ module Aws
           attr(name, Marshalers::NumericSetMarshaler.new(opts), opts)
         end
 
+        # what atomic counter is, how it works write here
+        # let them know all the to-dos before working with method
+        #
+
         # Define an atomic counter attribute for your model.
         # @param [Symbol] name Name of this attribute.  It should be a name that
         # is safe to use as a method.

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -386,8 +386,8 @@ module Aws
         # @param [Symbol] name Name of this attribute.  It should be a name that
         # is safe to use as a method.
         def atomic_counter(name, opts = {})
-          opts[:dynamodb_type] = "N" # setting the dynamoDB type to 'N' which is integer
-          opts[:default_value] ||= 0 # if user does not define default_value in their model, default is 0
+          opts[:dynamodb_type] = "N"
+          opts[:default_value] ||= 0
           attr(name, Marshalers::IntegerMarshaler.new(opts), opts)
 
           define_method("increment_#{name}!") do |increment=1|
@@ -418,8 +418,6 @@ module Aws
 
             @data.clean!
 
-            # after discussion with Alex, we agreed that the
-            # return value should be the current value of the atomic_counter
             @data.get_attribute(name)
 
           end

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -389,6 +389,31 @@ module Aws
           opts[:dynamodb_type] = "N" # setting the dynamoDB type to 'N' which is integer
           opts[:default_value] ||= 0 # if user does not define default_value in their model, default is 0
           attr(name, Marshalers::IntegerMarshaler.new(opts), opts)
+
+          # increment method with no args
+          define_method("increment_#{name}!") do
+            puts "Increasing #{name}!"
+
+            # need to pass in table name // self.class.table.name
+            # need to pass in keys (hash) // key_values
+            # expression attribute names // #n = name
+            # expression attribute values // :i = 1 (default value)
+            # update expression // SET #n = #n + :i
+            # return_values // UPDATED_NEW
+
+            resp = dynamodb_client.update_item({
+              table_name: self.class.table_name,
+              key: key_values,
+              expression_attribute_values: {
+                ":i" => 1
+              },
+              expression_attribute_names: {
+                "#n" => name
+              },
+              update_expression: "SET #n = #n + :i",
+              return_values: "UPDATED_NEW"
+            })
+          end
         end
 
         # @return [Symbol,nil] The symbolic name of the table's hash key.

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -397,13 +397,13 @@ module Aws
             # this to today's ruby standards
             # also - would this be considered to be a RecordError?
             if dirty?
-              msg = "Attributes need to be saved before proceeding"
+              msg = "Attributes need to be saved before atomic counter can be incremented"
               raise Errors::RecordError, msg
             end
 
             # check if passed-in arg is an integer
             # if it is not, need to raise Error
-            if !increment.is_a?(Integer)
+            unless increment.is_a?(Integer) # look into unless keyword
               msg = "expected an Integer value, got #{increment.class}"
               raise ArgumentError, msg
             end
@@ -425,7 +425,9 @@ module Aws
             assign_attributes(resp[:attributes])
             # returns true when completed
             # do we want something else to be returned at end
-            save
+            @data.clean!
+
+            # return the current value of the counter
           end
 
 

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -391,7 +391,7 @@ module Aws
           attr(name, Marshalers::IntegerMarshaler.new(opts), opts)
 
           # increment method with no args
-          define_method("increment_#{name}!") do |arg=1|
+          define_method("increment_#{name}!") do |increment=1|
             puts "Increasing #{name}!"
 
             # need to discuss how I can update
@@ -408,7 +408,7 @@ module Aws
               table_name: self.class.table_name,
               key: key_values,
               expression_attribute_values: {
-                ":i" => arg
+                ":i" => increment
               },
               expression_attribute_names: {
                 "#n" => name
@@ -417,6 +417,8 @@ module Aws
               return_values: "UPDATED_NEW"
             })
             assign_attributes(resp[:attributes])
+            # returns true when completed
+            # do we want something else to be returned at end
             save
           end
 

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -402,6 +402,13 @@ module Aws
               )
             end
 
+            # check if passed-in arg is an integer
+            # if it is not, need to raise Error
+            if !increment.is_a?(Integer)
+              msg = "expected an Integer value, got #{increment.class}"
+              raise ArgumentError, msg
+            end
+
             # will successfully update the
             # atomic_counter by 1 by default
             resp = dynamodb_client.update_item({

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -386,10 +386,8 @@ module Aws
         # @param [Symbol] name Name of this attribute.  It should be a name that
         # is safe to use as a method.
         def atomic_counter(name, opts = {})
-          opts[:dynamodb_type] = "N"
-          # do i need to set the default value to 0 from the start?
-          # or does leaving it out and setting to nil the same as setting to 0?
-          # I might have to define it since nil is considered to be no value?
+          opts[:dynamodb_type] = "N" # setting the dynamoDB type to 'N' which is integer
+          opts[:default_value] ||= 0 # if user does not define default_value in their model, default is 0
           attr(name, Marshalers::IntegerMarshaler.new(opts), opts)
         end
 

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -417,6 +417,7 @@ module Aws
               return_values: "UPDATED_NEW"
             })
             assign_attributes(resp[:attributes])
+            save
           end
 
 

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -385,7 +385,12 @@ module Aws
         # Define an atomic counter attribute for your model.
         # @param [Symbol] name Name of this attribute.  It should be a name that
         # is safe to use as a method.
-        def atomic_counter(name, default_value = 0)
+        def atomic_counter(name, opts = {})
+          opts[:dynamodb_type] = "N"
+          # do i need to set the default value to 0 from the start?
+          # or does leaving it out and setting to nil the same as setting to 0?
+          # I might have to define it since nil is considered to be no value?
+          attr(name, Marshalers::IntegerMarshaler.new(opts), opts)
         end
 
         # @return [Symbol,nil] The symbolic name of the table's hash key.

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -382,13 +382,41 @@ module Aws
           attr(name, Marshalers::NumericSetMarshaler.new(opts), opts)
         end
 
-        # what atomic counter is, how it works write here
-        # let them know all the to-dos before working with method
-        #
-
         # Define an atomic counter attribute for your model.
+        #
+        # Atomic counter are an integer-type attribute that is incremented,
+        # unconditionally, without interfering with other write requests.
+        # The numeric value increments each time you call +increment_<attr>!+.
+        # If a specific numeric value are passed in the call, the attribute will
+        # increment by that value.
+        #
+        # To use +increment_<attr>!+ method, the following condition must be true:
+        # * None of the attributes have dirty changes.
+        # * If there is a value passed in, it must be an integer.
+        # For more information, see
+        # {https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithItems.html#WorkingWithItems.AtomicCounters Atomic counter}
+        # in the Amazon DynamoDB Developer Guide.
+        #
         # @param [Symbol] name Name of this attribute.  It should be a name that
-        # is safe to use as a method.
+        #   is safe to use as a method.
+        # @param [Hash] opts
+        # @option opts [Object] :default_value Optional attribute used to
+        #   define a "default value" to be used if the attribute's value on an
+        #   item is nil or not set at persistence time. The "default value" of
+        #   the attribute starts at 0.
+        #
+        # @example Usage Example
+        #   class MyRecord
+        #     include Aws::Record
+        #     integer_attr :id, hash_key: true
+        #     atomic_counter :counter
+        #   end
+        #
+        #   record = MyRecord.new(id: 1)
+        #   record.counter #=> 0
+        #   record.increment_counter! #=> 1
+        #   record.increment_counter!(2) #=> 3
+        # @see #attr #attr method for additional hash options.
         def atomic_counter(name, opts = {})
           opts[:dynamodb_type] = "N"
           opts[:default_value] ||= 0

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -394,13 +394,16 @@ module Aws
           define_method("increment_#{name}!") do
             puts "Increasing #{name}!"
 
-            # need to pass in table name // self.class.table.name
-            # need to pass in keys (hash) // key_values
-            # expression attribute names // #n = name
-            # expression attribute values // :i = 1 (default value)
-            # update expression // SET #n = #n + :i
-            # return_values // UPDATED_NEW
+            # need to discuss how I can update
+            # this to today's standards
+            if dirty?
+              raise Errors::RecordError.new(
+                "Time to Take a Bath"
+              )
+            end
 
+            # will successfully update the
+            # atomic_counter by 1
             resp = dynamodb_client.update_item({
               table_name: self.class.table_name,
               key: key_values,
@@ -415,6 +418,11 @@ module Aws
             })
             assign_attributes(resp[:attributes])
           end
+
+
+
+
+
         end
 
         # @return [Symbol,nil] The symbolic name of the table's hash key.

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -382,6 +382,12 @@ module Aws
           attr(name, Marshalers::NumericSetMarshaler.new(opts), opts)
         end
 
+        # Define an atomic counter attribute for your model.
+        # @param [Symbol] name Name of this attribute.  It should be a name that
+        # is safe to use as a method.
+        def atomic_counter(name, default_value = 0)
+        end
+
         # @return [Symbol,nil] The symbolic name of the table's hash key.
         def hash_key
           @keys.hash_key

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -413,6 +413,7 @@ module Aws
               update_expression: "SET #n = #n + :i",
               return_values: "UPDATED_NEW"
             })
+            assign_attributes(resp[:attributes])
           end
         end
 

--- a/lib/aws-record/record/attributes.rb
+++ b/lib/aws-record/record/attributes.rb
@@ -415,12 +415,10 @@ module Aws
               return_values: "UPDATED_NEW"
             })
             assign_attributes(resp[:attributes])
-
             @data.clean!
-
             @data.get_attribute(name)
-
           end
+
         end
 
         # @return [Symbol,nil] The symbolic name of the table's hash key.

--- a/spec/aws-record/record/attributes_spec.rb
+++ b/spec/aws-record/record/attributes_spec.rb
@@ -153,8 +153,25 @@ module Aws
       end
 
       describe '#atomic_counter' do
+        context 'given a default value set in class attribute' do
+          it 'should override the existing default value' do
+            klass.string_attr(:id, hash_key: true)
+            klass.atomic_counter(:counter, default_value: 5)
+            item = klass.new(id: "MyId")
+            expect(item.counter).to eq(5)
+          end
         end
 
+        context 'since no default value set in class attribute' do
+          it 'should be the existing default value' do
+            klass.string_attr(:id, hash_key: true)
+            klass.atomic_counter(:counter)
+            item = klass.new(id: "MyId")
+            # noted as unable to find but still able to find??
+            expect(item.counter).to eq(0)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/aws-record/record/attributes_spec.rb
+++ b/spec/aws-record/record/attributes_spec.rb
@@ -171,6 +171,14 @@ module Aws
             expect(item.counter).to eq(0)
           end
         end
+
+        it 'should be able to reassign default value after creation' do
+          klass.string_attr(:id, hash_key: true)
+          klass.atomic_counter(:counter, default_value: 5)
+          item = klass.new(id: "MyId")
+          item.counter = 10
+          expect(item.counter).to eq(10)
+        end
       end
     end
   end

--- a/spec/aws-record/record/attributes_spec.rb
+++ b/spec/aws-record/record/attributes_spec.rb
@@ -153,23 +153,18 @@ module Aws
       end
 
       describe '#atomic_counter' do
-        context 'given a default value set in class attribute' do
-          it 'should override the existing default value' do
-            klass.string_attr(:id, hash_key: true)
-            klass.atomic_counter(:counter, default_value: 5)
-            item = klass.new(id: "MyId")
-            expect(item.counter).to eq(5)
-          end
+        it 'should override the existing default value' do
+          klass.string_attr(:id, hash_key: true)
+          klass.atomic_counter(:counter, default_value: 5)
+          item = klass.new(id: "MyId")
+          expect(item.counter).to eq(5)
         end
 
-        context 'since no default value set in class attribute' do
-          it 'should be the existing default value' do
-            klass.string_attr(:id, hash_key: true)
-            klass.atomic_counter(:counter)
-            item = klass.new(id: "MyId")
-            # noted as unable to find but still able to find??
-            expect(item.counter).to eq(0)
-          end
+        it 'should be the existing default value' do
+          klass.string_attr(:id, hash_key: true)
+          klass.atomic_counter(:counter)
+          item = klass.new(id: "MyId")
+          expect(item.counter).to eq(0)
         end
 
         it 'should be able to reassign default value after creation' do

--- a/spec/aws-record/record/attributes_spec.rb
+++ b/spec/aws-record/record/attributes_spec.rb
@@ -228,6 +228,34 @@ module Aws
               update_expression:"SET #n = #n + :i"
             })
           end
+
+          it 'should increment the atomic counter by a custom value' do
+            # set up
+            stub_client.stub_responses(:update_item,
+               {
+                 attributes:
+                   {
+                     'counter' => 2
+                   }
+               })
+            klass.configure_client(client: stub_client)
+
+            # action
+            item = klass.new(id: 1)
+            item.save!
+            item.increment_counter!(2)
+
+            # result
+            expect(item.counter).to eq(2)
+            expect(api_requests[1]). to eq({
+             expression_attribute_names: {"#n"=>"counter"},
+             expression_attribute_values: {":i"=>{:n=>"2"}},
+             key: {"id"=>{:n=>"1"}},
+             return_values: "UPDATED_NEW",
+             table_name: "TestTable",
+             update_expression:"SET #n = #n + :i"
+           })
+          end
         end
       end
 

--- a/spec/aws-record/record/attributes_spec.rb
+++ b/spec/aws-record/record/attributes_spec.rb
@@ -261,6 +261,14 @@ module Aws
             item = klass.new(id: 1)
             expect { item.increment_counter! }.to raise_error(Errors::RecordError)
           end
+
+          it 'will raise when arg is not an integer' do
+            klass.configure_client(client: stub_client)
+            item = klass.new(id: 1)
+            item.save!
+            increment = "wow"
+            expect {item.increment_counter!(increment)}.to raise_error(ArgumentError)
+          end
         end
       end
 

--- a/spec/aws-record/record/attributes_spec.rb
+++ b/spec/aws-record/record/attributes_spec.rb
@@ -177,6 +177,10 @@ module Aws
 
         describe '#incrementing_<attr>!' do
 
+          before(:each) do
+            klass.configure_client(client: stub_client)
+          end
+
           let(:klass) do
             Class.new do
               include(Aws::Record)
@@ -199,7 +203,6 @@ module Aws
           end
 
           it 'should increment atomic counter by default value' do
-            # set up
             stub_client.stub_responses(:update_item,
                {
                  attributes:
@@ -207,17 +210,11 @@ module Aws
                      'counter' => 1
                    }
                })
-            klass.configure_client(client: stub_client) # connecting to the class?
-            # left some comments here to show Alex some issues i'm running into
-            # klass.integer_attr(:id, hash_key: true)
-            # klass.atomic_counter(:counter)
 
-            # action
             item = klass.new(id: 1)
             item.save!
             item.increment_counter!
 
-            # result
             expect(item.counter).to eq(1)
             expect(api_requests[1]). to eq({
               expression_attribute_names: {"#n"=>"counter"},
@@ -230,7 +227,6 @@ module Aws
           end
 
           it 'should increment the atomic counter by a custom value' do
-            # set up
             stub_client.stub_responses(:update_item,
                {
                  attributes:
@@ -238,14 +234,11 @@ module Aws
                      'counter' => 2
                    }
                })
-            klass.configure_client(client: stub_client)
 
-            # action
             item = klass.new(id: 1)
             item.save!
             item.increment_counter!(2)
 
-            # result
             expect(item.counter).to eq(2)
             expect(api_requests[1]). to eq({
              expression_attribute_names: {"#n"=>"counter"},
@@ -263,7 +256,6 @@ module Aws
           end
 
           it 'will raise when arg is not an integer' do
-            klass.configure_client(client: stub_client)
             item = klass.new(id: 1)
             item.save!
             expect {item.increment_counter!("foo")}.to raise_error(ArgumentError)

--- a/spec/aws-record/record/attributes_spec.rb
+++ b/spec/aws-record/record/attributes_spec.rb
@@ -266,8 +266,7 @@ module Aws
             klass.configure_client(client: stub_client)
             item = klass.new(id: 1)
             item.save!
-            increment = "wow"
-            expect {item.increment_counter!(increment)}.to raise_error(ArgumentError)
+            expect {item.increment_counter!("foo")}.to raise_error(ArgumentError)
           end
         end
       end

--- a/spec/aws-record/record/attributes_spec.rb
+++ b/spec/aws-record/record/attributes_spec.rb
@@ -256,6 +256,11 @@ module Aws
              update_expression:"SET #n = #n + :i"
            })
           end
+
+          it 'will raise when incrementing on a dirty item' do
+            item = klass.new(id: 1)
+            expect { item.increment_counter! }.to raise_error(Errors::RecordError)
+          end
         end
       end
 

--- a/spec/aws-record/record/attributes_spec.rb
+++ b/spec/aws-record/record/attributes_spec.rb
@@ -152,6 +152,9 @@ module Aws
         end
       end
 
+      describe '#atomic_counter' do
+        end
+
     end
   end
 end


### PR DESCRIPTION
*Issue #, if available:* 
#114 

*Description of changes:*
Atomic counter are an integer-type attribute that is incremented, unconditionally, without interfering with other write requests. The numeric value increments each time you call `increment_<attr>!`. If a specific numeric value are passed in the call, the attribute will increment by that value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
