### PR TITLE
Allow default value for String/Numeric Sets to be unset

### DIFF
--- a/lib/aws-record/record/attribute.rb
+++ b/lib/aws-record/record/attribute.rb
@@ -40,8 +40,12 @@ module Aws
         @dynamodb_type = options[:dynamodb_type]
         @marshaler = options[:marshaler] || DefaultMarshaler
         @persist_nil = options[:persist_nil]
-        dv = options[:default_value]
-        @default_value_or_lambda = _is_lambda?(dv) ? dv : type_cast(dv)
+        @default_value_or_lambda = if options.key?(:default_value)
+          dv = options[:default_value]
+          _is_lambda?(dv) ? dv : type_cast(dv)
+        else
+          nil
+        end
       end
 
       # Attempts to type cast a raw value into the attribute's type. This call

--- a/spec/aws-record/record/attribute_spec.rb
+++ b/spec/aws-record/record/attribute_spec.rb
@@ -50,6 +50,18 @@ module Aws
 
           expect(a.default_value).to eq({})
         end
+
+        it 'does not type_cast unset value' do
+          m = Marshalers::StringSetMarshaler.new
+          a = Attribute.new(:foo, marshaler: m)
+          expect(a.default_value).to be_nil
+        end
+
+        it 'type casts nil value' do
+          m = Marshalers::StringSetMarshaler.new
+          a = Attribute.new(:foo, marshaler: m, default_value: nil)
+          expect(a.default_value).to be_a(Set)
+        end
       end
     end
   end


### PR DESCRIPTION
*Description of changes:*

The fix in #112 had the side effect of calling `type_cast` on `nil` if the `default_value` was unset.

Because the `StringSetMarshaler` and `NumericSetMarshaler` both convert `nil` to `Set.new`, this caused the unset default value in practice to become `Set.new` instead of `nil`.

Ultimately this caused downstream effects such as always persisting empty or unset sets as `nil` despite the `#persist_nil?` returning `false`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
