### PR TITLE
Support custom update expressions when update has no other attribute changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased Changes
 ------------------
 
+* Feature - Allow custom `update_expression` to be passed through to the 
+  underlying client calls. (#137)
+
 2.12.0 (2023-09-28)
 ------------------
 

--- a/lib/aws-record/record/errors.rb
+++ b/lib/aws-record/record/errors.rb
@@ -60,6 +60,13 @@ module Aws
       # the key existance check yourself in your condition expression if you
       # wish to do so.
       class TransactionalSaveConditionCollision < RuntimeError; end
+
+      # Raised when you attempt to combine your own update expression with
+      # the update expression auto-generated from updates to an item's
+      # attributes. The path forward until this case is supported is to
+      # perform attribute updates yourself in your update expression if you
+      # wish to do so.
+      class UpdateExpressionCollision < RuntimeError; end
     end
   end
 end

--- a/lib/aws-record/record/item_operations.rb
+++ b/lib/aws-record/record/item_operations.rb
@@ -644,7 +644,7 @@ module Aws
           update_expression_opts.merge(pass_through_opts) do |key, expression_value, pass_through_value|
             case key
             when :update_expression
-              msg = 'Using pass-through update expression with attribute updates is not currently supported.'
+              msg = 'Using pass-through update expression with attribute updates is not supported.'
               raise Errors::UpdateExpressionCollision, msg
             else
               expression_value.merge(pass_through_value)

--- a/lib/aws-record/record/transactions.rb
+++ b/lib/aws-record/record/transactions.rb
@@ -294,12 +294,12 @@ module Aws
             if opts.include?(:update_expression)
               raise Errors::UpdateExpressionCollision,
                     'Transactional write includes updated attributes, yet an' \
-                      'update expression was also provided. This is not ' \
-                      'currently supported. You should rewrite this case to ' \
-                      'add any attribute updates to your own update ' \
-                      "expression if desired.\n" \
-                      "\tItem: #{JSON.pretty_unparse(update_record.to_h)}\n" \
-                      "\tExtra Options: #{JSON.pretty_unparse(opts)}"
+                    'update expression was also provided. This is not ' \
+                    'currently supported. You should rewrite this case to ' \
+                    'add any attribute updates to your own update ' \
+                    "expression if desired.\n" \
+                    "\tItem: #{JSON.pretty_unparse(update_record.to_h)}\n" \
+                    "\tExtra Options: #{JSON.pretty_unparse(opts)}"
             end
             uex, exp_attr_names, exp_attr_values = update_tuple
             opts[:update_expression] = uex

--- a/lib/aws-record/record/transactions.rb
+++ b/lib/aws-record/record/transactions.rb
@@ -284,25 +284,36 @@ module Aws
         def _transform_update_record(update_record, opts)
           # extract dirty attribute changes to perform an update
           opts[:table_name] = update_record.class.table_name
+          opts[:key] = update_record.send(:key_values)
           dirty_changes = update_record.send(:_dirty_changes_for_update)
           update_tuple = update_record.class.send(
             :_build_update_expression,
             dirty_changes
           )
-          uex, exp_attr_names, exp_attr_values = update_tuple
-          opts[:key] = update_record.send(:key_values)
-          opts[:update_expression] = uex
-          # need to combine expression attribute names and values
-          opts[:expression_attribute_names] = if (names = opts[:expression_attribute_names])
-                                                exp_attr_names.merge(names)
-                                              else
-                                                exp_attr_names
-                                              end
-          opts[:expression_attribute_values] = if (values = opts[:expression_attribute_values])
-                                                 exp_attr_values.merge(values)
-                                               else
-                                                 exp_attr_values
-                                               end
+          if update_tuple
+            if opts.include?(:update_expression)
+              raise Errors::UpdateExpressionCollision,
+                    'Transactional write includes updated attributes, yet an' \
+                      'update expression was also provided. This is not ' \
+                      'currently supported. You should rewrite this case to ' \
+                      'add any attribute updates to your own update ' \
+                      "expression if desired.\n" \
+                      "\tItem: #{JSON.pretty_unparse(update_record.to_h)}\n" \
+                      "\tExtra Options: #{JSON.pretty_unparse(opts)}"
+            end
+            uex, exp_attr_names, exp_attr_values = update_tuple
+            opts[:update_expression] = uex
+            # need to combine expression attribute names and values
+            opts[:expression_attribute_names] = [
+              exp_attr_names,
+              opts[:expression_attribute_names]
+            ].compact.reduce(&:merge)
+
+            opts[:expression_attribute_values] = [
+              exp_attr_values,
+              opts[:expression_attribute_values]
+            ].compact.reduce(&:merge)
+          end
           { update: opts }
         end
 

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -584,7 +584,6 @@ module Aws
                 expression_attribute_names: {
                   '#UE_A' => 'body'
                 },
-                expression_attribute_values: nil
               }
             ]
           )

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -583,7 +583,7 @@ module Aws
                 update_expression: 'REMOVE #UE_A',
                 expression_attribute_names: {
                   '#UE_A' => 'body'
-                },
+                }
               }
             ]
           )

--- a/spec/aws-record/record/item_operations_spec.rb
+++ b/spec/aws-record/record/item_operations_spec.rb
@@ -201,6 +201,38 @@ module Aws
           )
         end
 
+        it 'will call #update_item with pass through update expression for existing items' do
+          klass.configure_client(client: stub_client)
+          item = klass.new
+          item.id = 1
+          item.date = '2015-12-14'
+          item.body = 'Hello!'
+          item.clean! # I'm claiming that it is this way in the DB now.
+          item.save(
+            update_expression: 'SET #S = if_not_exists(#S, :s)',
+            expression_attribute_names: { '#S' => 'body' },
+            expression_attribute_values: { ':s' => 'Goodbye!' }
+          )
+          expect(api_requests).to eq(
+            [
+              {
+                table_name: 'TestTable',
+                key: {
+                  'id' => { n: '1' },
+                  'MyDate' => { s: '2015-12-14' }
+                },
+                update_expression: 'SET #S = if_not_exists(#S, :s)',
+                expression_attribute_names: {
+                  '#S' => 'body'
+                },
+                expression_attribute_values: {
+                  ':s' => { s: 'Goodbye!' }
+                }
+              }
+            ]
+          )
+        end
+
         it 'passes through options to #update_item and #put_item' do
           klass.configure_client(client: stub_client)
           item = klass.new
@@ -288,6 +320,23 @@ module Aws
 
           # None of this should have reached the API
           expect(api_requests).to eq([])
+        end
+
+        it 'raises an exception when attribute updates collide with an update expression' do
+          klass.configure_client(client: stub_client)
+          item = klass.new
+          item.id = 1
+          item.date = '2015-12-14'
+          item.body = 'Hello!'
+          item.clean! # I'm claiming that it is this way in the DB now.
+          item.body = 'Goodbye!'
+          expect {
+            item.save(
+              update_expression: 'SET #S = if_not_exists(#S, :s)',
+              expression_attribute_names: { '#S' => 'body' },
+              expression_attribute_values: { ':s' => 'Goodbye!' }
+            )
+          }.to raise_error(Aws::Record::Errors::UpdateExpressionCollision)
         end
 
         context 'modifications to default values' do
@@ -464,6 +513,38 @@ module Aws
           )
         end
 
+        it 'can find item and apply update if update expression provided' do
+          klass.configure_client(client: stub_client)
+          opts = {
+            update_expression: 'SET #S = if_not_exists(#S, :s)',
+            expression_attribute_names: {
+              '#S' => 'body'
+            },
+            expression_attribute_values: {
+              ':s' => 'Content'
+            }
+          }
+          klass.update({ id: 1, date: '2016-05-18' }, opts)
+          expect(api_requests).to eq(
+            [
+              {
+                table_name: 'TestTable',
+                key: {
+                  'id' => { n: '1' },
+                  'MyDate' => { s: '2016-05-18' }
+                },
+                update_expression: 'SET #S = if_not_exists(#S, :s)',
+                expression_attribute_names: {
+                  '#S' => 'body'
+                },
+                expression_attribute_values: {
+                  ':s' => { s: 'Content' }
+                }
+              }
+            ]
+          )
+        end
+
         it 'will recognize nil as a removal operation if nil not persisted' do
           klass.configure_client(client: stub_client)
           klass.update(id: 1, date: '2016-07-20', body: nil, persist_on_nil: nil)
@@ -502,7 +583,8 @@ module Aws
                 update_expression: 'REMOVE #UE_A',
                 expression_attribute_names: {
                   '#UE_A' => 'body'
-                }
+                },
+                expression_attribute_values: nil
               }
             ]
           )
@@ -529,6 +611,22 @@ module Aws
           update_opts = { id: 5, body: 'Fail' }
           expect { klass.update(update_opts) }.to raise_error(
             Aws::Record::Errors::KeyMissing
+          )
+        end
+
+        it 'raises if both attribute updates and update expression provided' do
+          klass.configure_client(client: stub_client)
+          opts = {
+            update_expression: 'SET #S = if_not_exists(#S, :s)',
+            expression_attribute_names: {
+              '#S' => 'body'
+            },
+            expression_attribute_values: {
+              ':s' => 'Content'
+            }
+          }
+          expect { klass.update({ id: 1, date: '2016-05-18', bool: false }, opts) }.to raise_error(
+            Aws::Record::Errors::UpdateExpressionCollision
           )
         end
       end


### PR DESCRIPTION
*Issue #, if available:*
Resolves aws/aws-sdk-ruby-record#137

*Description of changes:*

This is a minimal implementation to allow update expressions to be passed through directly to the api call. To avoid conflicts, an error is raised if an update expression would have been generated by the sdk to update dirty attributes.

Also: Adds support for pass-through API options to the class-level `.update` item operation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
