### PR TITLE
Do not try to hydrate undeclared attributes from storage on batch_read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 Unreleased Changes
 ------------------
 
+* Issue - Do not try to hydrate undeclared attributes from storage on `batch_read`.
+
 2.13.0 (2023-10-17)
 ------------------
 
-* Feature - Allow custom `update_expression` to be passed through to the 
+* Feature - Allow custom `update_expression` to be passed through to the
   underlying client calls. (#137)
 
 2.12.0 (2023-09-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased Changes
 ------------------
 
-* Issue - Do not try to hydrate undeclared attributes from storage on `batch_read`.
+* Issue - Do not try to hydrate undeclared attributes from storage on `batch_read`. (#139)
 
 2.13.0 (2023-10-17)
 ------------------

--- a/Gemfile
+++ b/Gemfile
@@ -32,4 +32,5 @@ end
 
 group :development do
   gem 'rubocop'
+  gem 'pry'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,6 @@ group :release do
 end
 
 group :development do
-  gem 'rubocop'
   gem 'pry'
+  gem 'rubocop'
 end

--- a/lib/aws-record/record/batch_read.rb
+++ b/lib/aws-record/record/batch_read.rb
@@ -173,6 +173,9 @@ module Aws
         new_item_opts = {}
         item.each do |db_name, value|
           name = item_class.attributes.db_to_attribute_name(db_name)
+
+          next unless name
+
           new_item_opts[name] = value
         end
         item = item_class.new(new_item_opts)

--- a/lib/aws-record/record/transactions.rb
+++ b/lib/aws-record/record/transactions.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ostruct'
+
 module Aws
   module Record
     module Transactions

--- a/spec/aws-record/record/batch_spec.rb
+++ b/spec/aws-record/record/batch_spec.rb
@@ -124,7 +124,7 @@ describe Aws::Record::Batch do
               { 'Food ID' => 2, 'dish' => 'Waffles', 'spicy' => false, 'gluten_free' => true }
             ],
             'DrinkTable' => [
-              { 'id' => 1, 'drink' => 'Hot Chocolate' }
+              { 'id' => 1, 'drink' => 'Hot Chocolate', 'gluten_free' => true }
             ]
           }
         )
@@ -138,19 +138,27 @@ describe Aws::Record::Batch do
         end
       end
 
+      let(:actual_food) { result.items[0] }
+      let(:actual_breakfast) { result.items[1] }
+      let(:actual_drink) { result.items[2] }
+
       it 'reads a batch of operations and returns modeled items' do
         expect(result).to be_an(Aws::Record::BatchRead)
         expect(result.items.size).to eq(3)
-        expect(result.items[0].class).to eq(food)
-        expect(result.items[1].class).to eq(breakfast)
-        expect(result.items[2].class).to eq(drink)
-        expect(result.items[0].dirty?).to be_falsey
-        expect(result.items[1].dirty?).to be_falsey
-        expect(result.items[2].dirty?).to be_falsey
-        expect(result.items[0].spicy).to be_falsey
-        expect(result.items[1].spicy).to be_falsey
-        expect(result.items[1].gluten_free).to be_truthy
-        expect(result.items[2].drink).to eq('Hot Chocolate')
+
+        expect(actual_food).to be_a(food)
+        expect(actual_food).to_not be_dirty
+        expect(actual_food.spicy).to be_falsey
+
+        expect(actual_breakfast).to be_a(breakfast)
+        expect(actual_breakfast).to_not be_dirty
+        expect(actual_breakfast.spicy).to be_falsey
+        expect(actual_breakfast.gluten_free).to be_truthy
+
+        expect(actual_drink).to be_a(drink)
+        expect(actual_drink).to_not be_dirty
+        expect(actual_drink.drink).to eq('Hot Chocolate')
+        expect(actual_drink).to_not respond_to(:gluten_free)
       end
 
       it 'is complete' do


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Hello all and thank you for the great gem. There is an asymmetry around hydrating records on read operations between canonical queries and batch reads. The asymmetry is located around undeclared attributes on the model class. 

## Example of model with undeclared attribute

```ruby
#
# Storage has ID, name and age.
#
class Model
  include Aws::Record
  
  string_attr :ID, hash_key: true
  string_attr :name
end
```
On the above model when using canonical queries like `Model.find(ID: '123')` or `Model.query(...)` any undeclared attributes are omitted when building the final model instance. So in the above case we will end up with a Model instance that does not have age hydrated onto it.

But if we use a Batch Read then the `build_item` method will try to call `#=` on Nil.

```
NoMethodError: undefined method `=' for an instance of Model
from /Users/nronas/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/aws-record-2.13.0/lib/aws-record/record/attributes.rb:69:in `block in initialize'
```

This PR just skips any storage attributes that are not declared on the model class when batch reading

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
