### PR TITLE
Allow GSI in TableConfig without capacity settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Allow `global_secondary_index` to be defined without supplying capacity settings. (#140)
+
 2.13.1 (2024-07-18)
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 Unreleased Changes
 ------------------
 
-* Issue - Allow `global_secondary_index` to be defined without supplying capacity settings. (#140)
+* Issue - Allow `global_secondary_index` to be defined in `TableConfig` without 
+  supplying capacity settings. (#140)
 
 2.13.1 (2024-07-18)
 ------------------

--- a/lib/aws-record/record/table_config.rb
+++ b/lib/aws-record/record/table_config.rb
@@ -176,7 +176,7 @@ module Aws
       # @api private
       def global_secondary_index(name, &block)
         gsi = GlobalSecondaryIndex.new
-        gsi.instance_eval(&block)
+        gsi.instance_eval(&block) if block_given?
         @global_secondary_indexes[name] = gsi
       end
 

--- a/spec/aws-record/record/table_config_spec.rb
+++ b/spec/aws-record/record/table_config_spec.rb
@@ -25,16 +25,26 @@ module Aws
         end
       end
 
-      it 'accepts global secondary indexes in the definition' do
-        TableConfig.define do |t|
-          t.model_class(TestModelWithGsi)
-          t.read_capacity_units(2)
-          t.write_capacity_units(2)
-          t.global_secondary_index(:gsi) do |i|
-            i.read_capacity_units(1)
-            i.write_capacity_units(1)
+      context 'global secondary indexes' do
+        it 'accepts with capacity settings defined' do
+          TableConfig.define do |t|
+            t.model_class(TestModelWithGsi)
+            t.read_capacity_units(2)
+            t.write_capacity_units(2)
+            t.global_secondary_index(:gsi) do |i|
+              i.read_capacity_units(1)
+              i.write_capacity_units(1)
+            end
+            t.client_options(stub_responses: true)
           end
-          t.client_options(stub_responses: true)
+        end
+
+        it 'accepts without capacity settings defined' do
+          TableConfig.define do |t|
+            t.model_class(TestModelWithGsi)
+            t.global_secondary_index(:gsi)
+            t.client_options(stub_responses: true)
+          end
         end
       end
 


### PR DESCRIPTION
Fixes #140 

*Description* 
* Allow `global_secondary_index` to be defined in `TableConfig` without supplying capacity settings.
* Manually tested against live service.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.